### PR TITLE
Don't quote the *, it will cause an error in newer DBAL versions

### DIFF
--- a/src/QueryBuilder/PageQueryBuilder.php
+++ b/src/QueryBuilder/PageQueryBuilder.php
@@ -67,7 +67,7 @@ final class PageQueryBuilder extends BaseQueryBuilder
                 $queryBuilder
                     ->select(
                         ...array_map(
-                            fn (string $field) => $this->connection->quoteIdentifier($field),
+                            fn (string $field) => ($field !== '*') ? $this->connection->quoteIdentifier($field) : $field,
                             $this->fields
                         )
                     )


### PR DESCRIPTION
Don't quote the *, it will cause an error in newer DBAL versions