### PR TITLE
Contao 5.4 TypeError: ($security) must be of type Symfony\Component\Security\Core\Security, Symfony\Bundle\SecurityBundle\Security given 

### DIFF
--- a/src/Items/PageItemsLoader.php
+++ b/src/Items/PageItemsLoader.php
@@ -13,7 +13,7 @@ use Doctrine\DBAL\Query\QueryBuilder;
 use Doctrine\DBAL\Result;
 use Hofff\Contao\Navigation\QueryBuilder\PageQueryBuilder;
 use Hofff\Contao\Navigation\Security\PagePermissionGuard;
-use Symfony\Component\Security\Core\Security;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface AS Security;
 
 use function array_diff;
 use function array_fill_keys;

--- a/src/QueryBuilder/BaseQueryBuilder.php
+++ b/src/QueryBuilder/BaseQueryBuilder.php
@@ -6,7 +6,7 @@ namespace Hofff\Contao\Navigation\QueryBuilder;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Query\QueryBuilder;
-use Symfony\Component\Security\Core\Security;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface AS Security;
 
 use function time;
 

--- a/src/QueryBuilder/PageQueryBuilder.php
+++ b/src/QueryBuilder/PageQueryBuilder.php
@@ -9,7 +9,7 @@ use Contao\StringUtil;
 use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Query\QueryBuilder;
-use Symfony\Component\Security\Core\Security;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface AS Security;
 
 use function array_flip;
 use function array_keys;

--- a/src/Security/PagePermissionGuard.php
+++ b/src/Security/PagePermissionGuard.php
@@ -7,7 +7,7 @@ namespace Hofff\Contao\Navigation\Security;
 use Contao\FrontendUser;
 use Contao\ModuleModel;
 use Contao\StringUtil;
-use Symfony\Component\Security\Core\Security;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface AS Security;
 
 use function array_intersect;
 


### PR DESCRIPTION
Ganz vergessen … gegen welchen Zweig gehen die PRs?

```json
"require": {
    "contao/conflicts": "@dev",
    "contao/manager-bundle": "5.4.*",
    "hofff/contao-navigation": "^2.0"
}
```

```
TypeError: Hofff\Contao\Navigation\QueryBuilder\BaseQueryBuilder::__construct(): Argument #2 ($security) must be of type Symfony\Component\Security\Core\Security, Symfony\Bundle\SecurityBundle\Security given, 
```

Beide implementieren `AuthorizationCheckerInterface`, das ist auch kompatibel mit der 4.13er.
