### PR TITLE
Fix undefined array key

### DIFF
--- a/src/EventListener/Dca/NavigationDcaListener.php
+++ b/src/EventListener/Dca/NavigationDcaListener.php
@@ -40,7 +40,11 @@ final class NavigationDcaListener
                 continue;
             }
 
-            $fields[$fieldName] = sprintf('%s <span class="tl_gray">[%s]</span>', $config['label'][0], $fieldName);
+            $fields[$fieldName] = sprintf(
+                '%s <span class="tl_gray">[%s]</span>',
+                $config['label'][0] ?? '',
+                $fieldName,
+            );
         }
 
         return $fields;


### PR DESCRIPTION
"Zusätzliche Seitenfelder": 

> Trying to access array offset on value of type null

Not all fields provide a label.

For example terminal42/contao-pageimage

![contao-navigation-no-label](https://github.com/user-attachments/assets/53de9257-7a52-4318-b985-b6f508775b58)